### PR TITLE
Brunch Hot Reload

### DIFF
--- a/assets/brunch-config.js
+++ b/assets/brunch-config.js
@@ -16,6 +16,9 @@ exports.config = {
     }
   },
 
+  watcher: {
+    usePolling: true
+  },
   notifications: false, 
 
   conventions: {

--- a/assets/brunch-config.js
+++ b/assets/brunch-config.js
@@ -16,6 +16,8 @@ exports.config = {
     }
   },
 
+  notifications: false, 
+
   conventions: {
     // This option sets where we should place non-css and non-js assets in.
     // By default, we set this to "/assets/static". Files in this directory

--- a/assets/package.json
+++ b/assets/package.json
@@ -14,7 +14,7 @@
     "babel-brunch": "6.1.1",
     "brunch": "^2.10.17",
     "clean-css-brunch": "2.10.0",
-    "elm": "^0.18.0",
+    "elm": "0.18.0",
     "elm-brunch": "^0.11.1",
     "nib": "^1.1.2",
     "stylus-brunch": "^2.10.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -12,12 +12,12 @@
   },
   "devDependencies": {
     "babel-brunch": "6.1.1",
-    "brunch": "^2.10.12",
+    "brunch": "^2.10.17",
     "clean-css-brunch": "2.10.0",
     "elm": "^0.18.0",
     "elm-brunch": "^0.11.1",
     "nib": "^1.1.2",
-    "stylus-brunch": "^2.10.0",
+    "stylus-brunch": "^2.10.1",
     "uglify-js-brunch": "2.10.0"
   }
 }


### PR DESCRIPTION
- Updating dependencies
- Pinning elm to 0.18.0
- Resolving hot reload error: 
  -- Brunch watchers crashes when a notify-send() method cannot be called 
  -- Notifications are now turned off
